### PR TITLE
Dropbox connector

### DIFF
--- a/sidekick-server/connectors/connector_utils.py
+++ b/sidekick-server/connectors/connector_utils.py
@@ -3,6 +3,7 @@ from .web_connector import WebConnector
 from .zendesk_connector import ZendeskConnector
 from .confluence_connector import ConfluenceConnector
 from .notion_connector import NotionConnector
+from .dropbox_connector import DropboxConnector
 from models.models import AppConfig, DataConnector
 from typing import Optional
 
@@ -14,6 +15,7 @@ def get_connector_for_id(connector_id: int, config: AppConfig, path: Optional[st
         None,
         NotionConnector(config=config),
         ZendeskConnector(config=config, folder_name=path),
-        ConfluenceConnector(config=config, space=path)
+        ConfluenceConnector(config=config, space=path),
+        DropboxConnector(config=config, folder_name=path)
     ]
     return connectors[index]

--- a/sidekick-server/connectors/dropbox_connector/__init__.py
+++ b/sidekick-server/connectors/dropbox_connector/__init__.py
@@ -1,0 +1,1 @@
+from .dropbox_connector import DropboxConnector

--- a/sidekick-server/connectors/dropbox_connector/dropbox_connector.py
+++ b/sidekick-server/connectors/dropbox_connector/dropbox_connector.py
@@ -1,0 +1,142 @@
+import requests
+import json
+from typing import Dict, List
+from models.models import Source, AppConfig, Document, DocumentMetadata, DataConnector, AuthorizationResult
+from appstatestore.statestore import StateStore
+from io import BytesIO
+from PyPDF2 import PdfReader
+import docx
+import uuid
+
+BASE_URL = "https://api.dropboxapi.com"
+
+
+class DropboxConnector(DataConnector):
+    source_type: Source = Source.dropbox
+    connector_id: int = 7
+    config: AppConfig
+    folder_name: str
+
+    def __init__(self, config: AppConfig, folder_name: str):
+        super().__init__(config=config, folder_name=folder_name)
+
+    async def authorize(self, api_key: str, subdomain: str, email: str) -> AuthorizationResult:
+        creds = {
+            "api_key": api_key,
+        }
+
+        headers = {
+            'Authorization': f'Bearer {api_key}',
+            'Content-Type': 'application/json',
+        }
+
+        json_data = {
+            'query': 'foo',
+        }
+
+        try:
+            response = requests.post(f'{BASE_URL}/2/check/user', headers=headers, json=json_data)
+            print("authorize response", response.status_code)
+            if response.status_code != 200:
+                print(f"Error: Unable to fetch articles. Status code: {response.status_code}")
+                return AuthorizationResult(authorized=False)
+        except Exception as e:
+            print(e)
+            return AuthorizationResult(authorized=False)
+
+        creds_string = json.dumps(creds)
+        StateStore().save_credentials(self.config, creds_string, self)
+        return AuthorizationResult(authorized=True)
+
+    def get_all_files_under_folder(self, api_key: str, folder_name: str):
+        headers = {
+            'Authorization': f"Bearer {api_key}",
+            'Content-Type': 'application/json',
+        }
+
+        json_data = {
+            'include_deleted': False,
+            'include_has_explicit_shared_members': False,
+            'include_media_info': False,
+            'include_mounted_folders': True,
+            'include_non_downloadable_files': True,
+            'path': f"/{folder_name}",
+            'recursive': True,
+        }
+
+        res = requests.post(f'{BASE_URL}/2/files/list_folder', headers=headers, json=json_data)
+        data = res.json()
+        files = data.get('entries')
+
+        file_metadata = []
+        for doc in files:
+            if doc.get('.tag') == "file":
+                document_name = doc.get('name')
+                file_type = document_name.split('.')[-1]
+                if doc.get('is_downloadable'):
+                    document_path = doc.get('path_lower')
+                    file_metadata.append((document_name, document_path, file_type))
+
+        return file_metadata
+
+    def extract_text_from_document(self, api_key: str, document_path: str, file_type: str):
+        path = {"path": document_path}
+        path = json.dumps(path)
+        headers = {
+            'Authorization': f'Bearer {api_key}',
+            'Dropbox-API-Arg': path,
+        }
+
+        response = requests.post('https://content.dropboxapi.com/2/files/download', headers=headers)
+        if response.status_code == 200:
+            content = response.content
+            if content:
+                text = ""
+                if file_type == "pdf":
+                    bytes_data = BytesIO(content)
+                    reader = PdfReader(bytes_data)
+                    for num in range(len(reader.pages)):
+                        page = reader.pages[num]
+                        page_text = page.extract_text()
+                        text += page_text
+
+                elif file_type == "docx" or file_type == "doc":
+                    bytes_data = BytesIO(content)
+                    doc = docx.Document(bytes_data)
+                    for p in doc.paragraphs:
+                        text += p.text
+
+                elif file_type == "txt":
+                    text = content.decode("utf-8")
+                return text
+        return None
+
+
+
+    async def load(self, source_id: str) -> List[Document]:
+        credential_string = StateStore().load_credentials(self.config, self)
+        credential_json = json.loads(credential_string)
+        api_key = credential_json["api_key"]
+
+        documents: List[Document] = []
+
+        files = self.get_all_files_under_folder(api_key, self.folder_name)
+
+        for file_name, file_path, file_type in files:
+            text = self.extract_text_from_document(api_key, file_path, file_type)
+            if text:
+                documents.append(
+                    Document(
+                        title=file_name,
+                        text=text,
+                        url=file_path,
+                        source_type=Source.dropbox,
+                        metadata=DocumentMetadata(
+                            document_id=str(uuid.uuid4()),
+                            source_id=source_id,
+                            tenant_id=self.config.tenant_id
+                        )
+                    )
+                )
+
+        return documents

--- a/sidekick-server/models/api.py
+++ b/sidekick-server/models/api.py
@@ -32,7 +32,10 @@ class AuthorizeWithApiKeyRequest(BaseModel):
     connector_id: int
     subdomain: Optional[str] = None
     email: Optional[str] = None
-    
+
+class AuthorizeWithApiKeyRequestV2(BaseModel):
+    connector_id: int
+    credentials: dict
 
 class AuthorizeResponse(BaseModel):
     authorized: bool

--- a/sidekick-server/models/api.py
+++ b/sidekick-server/models/api.py
@@ -27,20 +27,24 @@ class AuthorizeGoogleDriveRequest(BaseModel):
     redirect_uri: str
     auth_code: Optional[str]
 
+class AuthorizeOauthRequest(BaseModel):
+    redirect_uri: str
+    auth_code: Optional[str]
+    connector_id: int
+
 class AuthorizeWithApiKeyRequest(BaseModel):
     api_key: str
     connector_id: int
     subdomain: Optional[str] = None
     email: Optional[str] = None
 
-class AuthorizeWithApiKeyRequestV2(BaseModel):
-    connector_id: int
-    credentials: dict
-
 class AuthorizeResponse(BaseModel):
     authorized: bool
 
 class AuthorizeGoogleDriveResponse(AuthorizeResponse):
+    auth_url: Optional[str]
+
+class OauthResponse(AuthorizeResponse):
     auth_url: Optional[str]
 
 class AskLLMRequest(BaseModel):

--- a/sidekick-server/models/models.py
+++ b/sidekick-server/models/models.py
@@ -18,6 +18,7 @@ class Source(str, Enum):
     notion="notion"
     zendesk="zendesk"
     confluence="confluence"
+    dropbox="dropbox"
 
 class DocumentMetadata(BaseModel):
     document_id: str

--- a/sidekick-server/pyproject.toml
+++ b/sidekick-server/pyproject.toml
@@ -35,6 +35,7 @@ google-auth-httplib2 = "^0.1.0"
 google-api-python-client = "^2.83.0"
 atlassian-python-api = "^3.36.0"
 posthog = "^2.5.0"
+python-docx = "^0.8.11"
 
 [tool.poetry.scripts]
 start = "server.main:start"

--- a/sidekick-server/server/main.py
+++ b/sidekick-server/server/main.py
@@ -16,20 +16,19 @@ from models.api import (
     AuthorizeGoogleDriveRequest,
     UpsertGoogleDocsRequest,
     AuthorizeGoogleDriveResponse,
+    OauthResponse,
     LLMResponse,
     AskLLMRequest,
     UpsertRequest,
     AuthorizeResponse,
     AuthorizeWithApiKeyRequest,
-    AuthorizeWithApiKeyRequestV2,
-    UpsertFromConnectorRequest
+    UpsertFromConnectorRequest,
+    AuthorizeOauthRequest
 )
 
 from llm.LLM import LLM
 from connectors.google_docs_connector import GoogleDocsConnector
-from connectors.notion_connector import NotionConnector
 from connectors.web_connector import WebConnector
-from connectors.dropbox_connector import DropboxConnector
 from chunkers.html_chunker import HTMLChunker
 from chunkers.default_chunker import DefaultChunker
 
@@ -106,30 +105,27 @@ async def authorize_with_api_key(
 
 
 @app.post(
-    "/authorize-with-api-key-v2",
-    response_model=AuthorizeResponse,
+    "/authorize-oauth",
+    response_model=OauthResponse,
 )
-async def authorize_with_api_key_v2(
-        request: AuthorizeWithApiKeyRequestV2 = Body(...),
-        config: AppConfig = Depends(validate_token),
+async def authorize_oauth(
+    request: AuthorizeOauthRequest = Body(...),
+    config: AppConfig = Depends(validate_token),
 ):
-    try:
-        connector_id = request.connector_id
-        credentials = request.credentials
+    auth_code = request.auth_code
+    redirect_uri = request.redirect_uri
+    connector_id = request.connector_id
 
-        connector = get_connector_for_id(connector_id, config)
+    connector = get_connector_for_id(connector_id, config)
 
-        print("connector", connector)
+    print("connector", connector)
 
-        if connector is None:
-            raise HTTPException(status_code=404, detail="Connector not found")
+    if connector is None:
+        raise HTTPException(status_code=404, detail="Connector not found")
 
-        auth_result = await connector.authorize(credentials)
+    auth_url = await connector.authorize(redirect_uri, auth_code)
+    return OauthResponse(auth_url=auth_url, authorized=auth_url is None)
 
-        return AuthorizeResponse(authorized=auth_result.authorized)
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"str({e})")
-    
 
 @app.post(
     "/authorize-google-drive",
@@ -144,50 +140,6 @@ async def authorize_google_drive(
     google_connector = GoogleDocsConnector(config, "")
     auth_url = await google_connector.authorize(redirect_uri, auth_code)
     return AuthorizeGoogleDriveResponse(auth_url=auth_url, authorized=auth_url is None)
-
-
-@app.post(
-    "/authorize-dropbox",
-    response_model=AuthorizeGoogleDriveResponse,
-)
-async def authorize_dropbox(
-    request: AuthorizeGoogleDriveRequest = Body(...),
-    config: AppConfig = Depends(validate_token),
-):
-    auth_code = request.auth_code
-    redirect_uri = request.redirect_uri
-    dropbox_connector = DropboxConnector(config, "")
-    auth_url = await dropbox_connector.authorize(redirect_uri, auth_code)
-    return AuthorizeGoogleDriveResponse(auth_url=auth_url, authorized=auth_url is None)
-
-
-@app.post(
-    "/upsert-dropbox",
-    response_model=UpsertResponse,
-)
-async def upsert_dropbox(
-    request: UpsertGoogleDocsRequest = Body(...),
-    config: AppConfig = Depends(validate_token),
-):
-    folder_name = request.folder_name
-    source_id = str(uuid.uuid5(uuid.NAMESPACE_URL, request.folder_name))
-
-    try:
-        dropbox_connector = DropboxConnector(config, folder_name)
-
-        documents = await dropbox_connector.load(source_id=source_id)
-        chunker = DefaultChunker()
-        chunks = []
-        for doc in documents:
-            chunks.extend(chunker.chunk(source_id, doc, 1000))
-
-        ids = await datastore.upsert(chunks, tenant_id=config.tenant_id)
-
-        return UpsertResponse(ids=ids)
-
-    except Exception as e:
-        print("Error:", e)
-        raise HTTPException(status_code=500, detail=f"str({e})")
 
 
 @app.post(


### PR DESCRIPTION
I added OAuth for the dropbox connector as it was the only way to store a users credentials permanently. 
In the process I realized that the "/authorize-with-api-key" endpoint does not work well with some connectors because this endpoint requires api_key, subdomain, and email. Some connectors don't need those values so I created a separate endpoint "/authorize-with-api-key-v2" to address this issue. Let me know what you guys think of this new connector authorization style as well as the dropbox connector.